### PR TITLE
Fix a few bugs, add the possibility to override the extracted values

### DIFF
--- a/invenio_matcher/core.py
+++ b/invenio_matcher/core.py
@@ -61,6 +61,19 @@ def _merge(d1, d2):
     return result
 
 
+def _get_values(record, match):
+    """Retrieve the values from the record.
+
+    Ensures that the values will be a list, since this is what the
+    rest of the code expects.
+    """
+    result = record.get(match, [])
+    if not isinstance(result, list):
+        result = [result]
+
+    return result
+
+
 def _parse(query, record):
     """Parse a query and extract values from record."""
     try:
@@ -70,9 +83,12 @@ def _parse(query, record):
         raise InvalidQuery('Keys "type" and "match" not defined in query'
                            ' {query}'.format(query=query))
 
-    values = record[match]
+    # XXX(jacquerie): This allows the user to pass directly the values to be
+    # retrieved from the record. This is an advanced feature, therefore is
+    # not advertised in the public API.
+    values = query.get('values', _get_values(record, match))
     match = query.get('with', match)
     extras = {k: v for k, v in six.iteritems(
-        query) if k not in set(['type', 'match', 'with'])}
+        query) if k not in set(['type', 'match', 'with', 'values'])}
 
     return _type, match, values, extras

--- a/invenio_matcher/matcherext/engines/es.py
+++ b/invenio_matcher/matcherext/engines/es.py
@@ -81,6 +81,9 @@ def queries(index, doc_type, **kwargs):
 
 def _build_exact_query(match, values, **kwargs):
     """Build an exact query."""
+    if values == []:
+        return {}
+
     result = {
         'query': {
             'filtered': {

--- a/tests/engines/test_es.py
+++ b/tests/engines/test_es.py
@@ -174,6 +174,13 @@ class TestMatcherEngineES(InvenioTestCase):
 
         self.assertEqual(expected, result)
 
+    def test_build_exact_query_empty(self):
+        """Build an exact query from an empty list of values."""
+        expected = {}
+        result = _build_exact_query(match='titles.title', values=[])
+
+        self.assertEqual(expected, result)
+
     def test_build_exact_query_invalid_call(self):
         """Raise when the call is invalid."""
         with pytest.raises(TypeError) as excinfo:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -34,9 +34,14 @@ from invenio_matcher.models import MatchResult
 Record = lazy_import('invenio_records.api.Record')
 
 
+def data():
+    """Represent a record."""
+    return {'titles': [{'title': 'foo bar'}]}
+
+
 def simple_data():
     """Represent a simple record."""
-    return {'titles': [{'title': 'foo bar'}]}
+    return {'title': 'foo bar'}
 
 
 def no_results(query, record, **kwargs):
@@ -46,7 +51,7 @@ def no_results(query, record, **kwargs):
 
 def single_result(query, record, **kwargs):
     """Return a single result."""
-    return [MatchResult(Record(simple_data()), 1)]
+    return [MatchResult(Record(data()), 1)]
 
 
 def no_queries(**kwargs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,7 @@
 """Test Matcher API."""
 
 from helpers import (
-    no_queries, no_results, simple_data, single_query, single_result
+    data, no_queries, no_results, single_query, single_result
 )
 
 from invenio_base.wrappers import lazy_import
@@ -50,7 +50,7 @@ class TestMatcherAPI(InvenioTestCase):
 
     def setup_class(self):
         """Load data for a simple record."""
-        self.data = simple_data()
+        self.data = data()
 
     @mock.patch('invenio_matcher.api.get_queries', no_queries)
     def test_match_no_queries(self):


### PR DESCRIPTION
While integrating `invenio-matcher` in `inspire-next` I found a few bugs (the extracted values MUST be a list, an empty list of values results in generating an invalid ES query) and added the possibility to directly pass the extracted values to the matching process.

The idea is that sometimes (for example: when extracting arXiv ids) the logic to do that requires a few transformations, so the user might want to do those on her own, and then feed the extracted values to the matcher.
