### PR TITLE
core: return empty when no values

### DIFF
--- a/invenio_matcher/core.py
+++ b/invenio_matcher/core.py
@@ -33,8 +33,13 @@ from .errors import InvalidQuery, NotImplementedQuery
 
 
 def execute(query, record, **kwargs):
-    """Parse a query and send it to the engine."""
+    """Parse a query and send it to the engine, returning a list of hits."""
     _type, match, values, extras = _parse(query, record)
+
+    if not values:
+        # No values in the record to match with
+        return []
+
     _kwargs = _merge(kwargs, extras)
 
     if _type == 'exact':

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -88,6 +88,17 @@ class TestMatcherCore(InvenioTestCase):
             execute(query, record)
         self.assertIn('type foobar', str(excinfo.value))
 
+    @mock.patch('invenio_matcher.core.exact')
+    def test_execute_no_values(self, exact):
+        """In case the record does not contain the match value."""
+        query = {'type': 'exact', 'match': 'titles.title'}
+        record = Record({})
+
+        res = execute(query, record)
+
+        assert not exact.called, 'exact function should not have been called'
+        assert res == []
+
     @mock.patch('invenio_matcher.core.queries', single_query)
     def test_get_queries(self):
         """Dispatch the retrieval of queries."""


### PR DESCRIPTION
Otherwise, if record does not have the value we are matching for the search engine (ES in this case) might return all records as hits instead of none.
