### PR TITLE
core: allow passing doc directly to fuzzy query

### DIFF
--- a/invenio_matcher/core.py
+++ b/invenio_matcher/core.py
@@ -40,7 +40,7 @@ def execute(index, doc_type, query, record, **kwargs):
     """Parse a query and send it to the engine, returning a list of hits."""
     _type, match, values, extras = _parse(query, record)
 
-    if not values:
+    if not values and not _is_fuzzy_with_doc(query):
         # No values in the record to match with
         return []
 
@@ -67,6 +67,10 @@ def get_queries(index, doc_type, **kwargs):
         raise NoQueryDefined('No query defined for index {index} and doc_type'
                              ' {doc_type} in MATCHER_QUERIES.'.format(
                                  index=index, doc_type=doc_type))
+
+
+def _is_fuzzy_with_doc(query):
+    return query['type'] == 'fuzzy' and bool(query.get('doc'))
 
 
 def _build_result(hits):

--- a/invenio_matcher/engine.py
+++ b/invenio_matcher/engine.py
@@ -91,7 +91,9 @@ def _build_exact_query(match, values, **kwargs):
 
 def _build_fuzzy_query(index, doc_type, match, values, **kwargs):
     """Build a fuzzy query."""
-    doc = _build_doc(match, values)
+    doc = kwargs.pop('doc', {})
+    if not doc:
+        doc = _build_doc(match, values)
     result = _build_mlt_query(doc, index, doc_type, **kwargs)
 
     return result


### PR DESCRIPTION
* Allows passing a JSON document directly instead of having to pass
  the values. (closes #19)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>