### PR TITLE
core: allow passing a list of documents in match

### DIFF
--- a/invenio_matcher/core.py
+++ b/invenio_matcher/core.py
@@ -40,7 +40,7 @@ def execute(index, doc_type, query, record, **kwargs):
     """Parse a query and send it to the engine, returning a list of hits."""
     _type, match, values, extras = _parse(query, record)
 
-    if not values and not isinstance(match, dict):
+    if not values and not isinstance(match, (dict, list)):
         return []
 
     _kwargs = _merge(kwargs, extras)

--- a/tests/test_query_building.py
+++ b/tests/test_query_building.py
@@ -143,6 +143,69 @@ def test_build_fuzzy_query_accepts_a_doc():
     assert expected == result
 
 
+def test_build_fuzzy_query_accepts_a_list_of_docs():
+    """Build a fuzzy query from a passed list of documents."""
+    expected = {
+        "query": {
+            "dis_max": {
+                "tie_breaker": 0.3,
+                "queries": [
+                    {
+                        "more_like_this": {
+                            "min_doc_freq": 1,
+                            "docs": [
+                                {
+                                    "doc": {
+                                        "titles": [
+                                            {
+                                                "title": "foo bar"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "boost": 20,
+                            "max_query_terms": 25,
+                            "min_term_freq": 1
+                        }
+                    },
+                    {
+                        "more_like_this": {
+                            "min_doc_freq": 1,
+                            "docs": [
+                                {
+                                    "doc": {
+                                        "authors": [
+                                            {
+                                                "full_name": "Doe, John"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "boost": 1,
+                            "max_query_terms": 25,
+                            "min_term_freq": 1
+                        }
+                    }
+                ]
+            }
+        },
+        "min_score": 1
+    }
+    result = _build_fuzzy_query(
+        match=[
+            {'titles': [{'title': 'foo bar'}], 'boost': 20},
+            {'authors': [{'full_name': 'Doe, John'}]}
+        ],
+        values=[],
+        index='records',
+        doc_type='record',
+    )
+
+    assert expected == result
+
+
 def test_build_doc():
     """Build a surrogated document."""
     expected = {'titles': {'title': 'foo bar'}}


### PR DESCRIPTION
* If a list of documents is passed in a fuzzy query, a dis-max
  query is sent to ElasticSearch.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>